### PR TITLE
[PR] Implement a `wp wsuwp user` command

### DIFF
--- a/command.php
+++ b/command.php
@@ -4,12 +4,4 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-/**
- * Says "Hello World" to new users.
- *
- * @when before_wp_load
- */
-$hello_world_command = function() {
-	WP_CLI::success( "Hello world." );
-};
-WP_CLI::add_command( 'hello-world', $hello_world_command );
+include_once __DIR__ . '/commands/wsuwp-cli-users.php';

--- a/commands/wsuwp-cli-users.php
+++ b/commands/wsuwp-cli-users.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace WSUWP\CLI\User;
+use WP_CLI;
+
+/**
+ * WP-CLI commands for managing WSUWP.
+ *
+ * @package WSUWP\CLI\User;
+ */
+class Command {
+	/**
+	 * Create a new user.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user-email>
+	 * : The WSU email address of the user to create.
+	 *
+	 * [--first_name=<first_name>]
+	 * : The user's first name.
+	 *
+	 * [--last_name=<last_name>]
+	 * : The user's last name.
+	 *
+	 * [--porcelain]
+	 * : Output just the new user id.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Create user
+	 *     $ wp user create jeremy.felt@wsu.edu
+	 *     Success: Created user ID 3 for WSU NID jeremy.felt.
+	 *
+	 *     # Create user without showing password upon success
+	 *     $ wp user create jeremy.felt@wsu.edu --porcelain
+	 *     4
+	 */
+	public function create( $args, $assoc_args ) {
+		$user = new \stdClass;
+
+		list( $user->user_email ) = $args;
+
+		$assoc_args = wp_slash( $assoc_args );
+
+		if ( ! is_email( $user->user_email ) ) {
+			WP_CLI::error( "'{$user->user_email}' is not a valid email." );
+		}
+
+		$user_parts = explode( '@', $user->user_email );
+
+		if ( 'wsu.edu' !== $user_parts[1] ) {
+			WP_CLI::error( "'{$user->user_email}' is not a valid WSU email." );
+		}
+
+		$user->user_login = $user_parts[0];
+
+		if ( username_exists( $user->user_login ) ) {
+			WP_CLI::error( "The '{$user->user_login}' username is already registered." );
+		}
+
+		$user->first_name = WP_CLI\Utils\get_flag_value( $assoc_args, 'first_name', false );
+
+		$user->last_name = WP_CLI\Utils\get_flag_value( $assoc_args, 'last_name', false );
+
+		$user->user_pass = wp_generate_password( 24 );
+
+		add_filter( 'send_password_change_email', '__return_false' );
+		add_filter( 'send_email_change_email', '__return_false' );
+
+		if ( is_multisite() ) {
+			$ret = wpmu_validate_user_signup( $user->user_login, $user->user_email );
+			if ( is_wp_error( $ret['errors'] ) && ! empty( $ret['errors']->errors ) ) {
+				WP_CLI::error( $ret['errors'] );
+			}
+			$user_id = wpmu_create_user( $user->user_login, $user->user_pass, $user->user_email );
+			if ( ! $user_id ) {
+				WP_CLI::error( "Unknown error creating new user." );
+			}
+			$user->ID = $user_id;
+			$user_id = wp_update_user( $user );
+			if ( is_wp_error( $user_id ) ) {
+				WP_CLI::error( $user_id );
+			}
+		} else {
+			$user_id = wp_insert_user( $user );
+		}
+
+		if ( ! $user_id || is_wp_error( $user_id ) ) {
+			if ( ! $user_id ) {
+				$user_id = 'Unknown error creating new user.';
+			}
+			WP_CLI::error( $user_id );
+		}
+
+		delete_user_option( $user_id, 'capabilities' );
+		delete_user_option( $user_id, 'user_level' );
+
+		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			WP_CLI::line( $user_id );
+		} else {
+			WP_CLI::success( "Created user $user_id." );
+		}
+	}
+}
+WP_CLI::add_command( 'wsuwp user', 'WSUWP\CLI\User\Command' );

--- a/commands/wsuwp-cli-users.php
+++ b/commands/wsuwp-cli-users.php
@@ -79,9 +79,6 @@ class Command {
 			}
 			$user->ID = $user_id;
 			$user_id = wp_update_user( $user );
-			if ( is_wp_error( $user_id ) ) {
-				WP_CLI::error( $user_id );
-			}
 		} else {
 			$user_id = wp_insert_user( $user );
 		}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -40,7 +40,7 @@ if ( file_exists( __DIR__ . '/utils.php' ) ) {
  */
 class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
-	private static $cache_dir, $suite_cache_dir;
+	private static $cache_dir, $suite_cache_dir, $mu_cache_dir;
 
 	private static $db_settings = array(
 		'dbname' => 'wp_cli_test',
@@ -307,10 +307,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		$this->proc( Utils\esc_cmd( "cp -r %s/* %s", self::$cache_dir, $dest_dir ) )->run_check();
-
-		// disable emailing
-		mkdir( $dest_dir . '/wp-content/mu-plugins' );
-		copy( __DIR__ . '/../extra/no-mail.php', $dest_dir . '/wp-content/mu-plugins/no-mail.php' );
 	}
 
 	public function create_config( $subdir = '' ) {
@@ -340,43 +336,58 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	public function setup_wsuwp( $subdir = '' ) {
+		self::$mu_cache_dir = sys_get_temp_dir() . '/wsuwp-cli-mu-plugin-cache';
+
 		$dest_dir = $this->variables['RUN_DIR'] . "/$subdir";
+
+		if ( ! is_dir( self::$mu_cache_dir ) ) {
+			mkdir( self::$mu_cache_dir );
+		}
 
 		if ( $subdir ) {
 			mkdir( $dest_dir );
 		}
 
-		$this->proc( Utils\esc_cmd( "cp -r %s/* %s", self::$cache_dir, $dest_dir ) )->run_check();
-
-		if ( ! is_dir( $dest_dir . '/wp-content/mu-plugins' ) ) {
-			mkdir( $dest_dir . '/wp-content/mu-plugins' );
+		if ( ! is_dir( self::$mu_cache_dir . '/wsuwp-load-mu-plugins' ) ) {
+			mkdir( self::$mu_cache_dir . '/wsuwp-load-mu-plugins' );
 		}
 
-		if ( ! is_dir( $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins' ) ) {
-			mkdir( $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins' );
-		}
-
-		copy( __DIR__ . '/../extra/wsuwp-load-mu-plugins.php', $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins/wsuwp-load-mu-plugins.php' );
+		copy( __DIR__ . '/../extra/wsuwp-load-mu-plugins.php', self::$mu_cache_dir . '/wsuwp-load-mu-plugins/wsuwp-load-mu-plugins.php' );
+		copy( __DIR__ . '/../extra/no-mail.php', self::$mu_cache_dir . '/no-mail.php' );
 
 		$wsuwp_platform_loader = 'https://github.com/washingtonstateuniversity/WSUWP-Platform/raw/master/www/wp-content/mu-plugins/index.php';
 		$wsuwp_multinetwork_plugin = 'https://github.com/washingtonstateuniversity/WSUWP-Plugin-Multiple-Networks/archive/master.zip';
 		$wsuwp_simple_filters_plugin = 'https://github.com/washingtonstateuniversity/WSUWP-Plugin-MU-Simple-Filters/archive/master.zip';
 
-		$this->proc( Utils\esc_cmd(
-			'curl -sSfL %1$s > %2$s',
-			$wsuwp_platform_loader,
-			$dest_dir . 'wp-content/mu-plugins/index.php'
-		) )->run_check();
+		if ( ! is_file( self::$mu_cache_dir . '/index.php' ) ) {
+			echo 'downloading index.php';
+			$this->proc( Utils\esc_cmd(
+				'curl -sSfL %1$s > %2$s',
+				$wsuwp_platform_loader,
+				self::$mu_cache_dir . '/index.php'
+			) )->run_check();
+		}
 
-		$this->proc( Utils\esc_cmd(
-			'curl -sSfL %1$s > master.zip && unzip master.zip && mv WSUWP-Plugin-Multiple-Networks-master wp-content/mu-plugins/wsuwp-multiple-networks && rm master.zip',
-			$wsuwp_multinetwork_plugin
-		) )->run_check();
+		if ( ! is_dir( self::$mu_cache_dir . '/wsuwp-multiple-networks' ) ) {
+			echo 'downloading multi network';
+			$this->proc( Utils\esc_cmd(
+				'curl -sSfL %1$s > master.zip && unzip master.zip -d %2$s && mv %2$sWSUWP-Plugin-Multiple-Networks-master %2$swsuwp-multiple-networks && rm master.zip',
+				$wsuwp_multinetwork_plugin,
+				self::$mu_cache_dir . '/'
+			) )->run_check();
+		}
 
-		$this->proc( Utils\esc_cmd(
-			'curl -sSfL %1$s > master.zip && unzip master.zip && mv WSUWP-Plugin-MU-Simple-Filters-master wp-content/mu-plugins/wsuwp-mu-simple-filters && rm master.zip',
-			$wsuwp_simple_filters_plugin
-		) )->run_check();
+		if ( ! is_dir( self::$mu_cache_dir . '/wsuwp-mu-simple-filters' ) ) {
+			echo 'downloading simple filters';
+			$this->proc( Utils\esc_cmd(
+				'curl -sSfL %1$s > master.zip && unzip master.zip -d %2$s && mv %2$sWSUWP-Plugin-MU-Simple-Filters-master %2$swsuwp-mu-simple-filters && rm master.zip',
+				$wsuwp_simple_filters_plugin,
+				self::$mu_cache_dir . '/'
+			) )->run_check();
+		}
+
+		$this->proc( Utils\esc_cmd( 'mkdir -p %s', $dest_dir . 'wp-content/mu-plugins' ) )->run_check();
+		$this->proc( Utils\esc_cmd( "cp -r %s/* %s", self::$mu_cache_dir, $dest_dir . 'wp-content/mu-plugins' ) )->run_check();
 	}
 }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -360,7 +360,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$wsuwp_simple_filters_plugin = 'https://github.com/washingtonstateuniversity/WSUWP-Plugin-MU-Simple-Filters/archive/master.zip';
 
 		if ( ! is_file( self::$mu_cache_dir . '/index.php' ) ) {
-			echo 'downloading index.php';
 			$this->proc( Utils\esc_cmd(
 				'curl -sSfL %1$s > %2$s',
 				$wsuwp_platform_loader,
@@ -369,7 +368,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		if ( ! is_dir( self::$mu_cache_dir . '/wsuwp-multiple-networks' ) ) {
-			echo 'downloading multi network';
 			$this->proc( Utils\esc_cmd(
 				'curl -sSfL %1$s > master.zip && unzip master.zip -d %2$s && mv %2$sWSUWP-Plugin-Multiple-Networks-master %2$swsuwp-multiple-networks && rm master.zip',
 				$wsuwp_multinetwork_plugin,
@@ -378,7 +376,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		if ( ! is_dir( self::$mu_cache_dir . '/wsuwp-mu-simple-filters' ) ) {
-			echo 'downloading simple filters';
 			$this->proc( Utils\esc_cmd(
 				'curl -sSfL %1$s > master.zip && unzip master.zip -d %2$s && mv %2$sWSUWP-Plugin-MU-Simple-Filters-master %2$swsuwp-mu-simple-filters && rm master.zip',
 				$wsuwp_simple_filters_plugin,

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -338,5 +338,45 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$this->proc( 'wp core install', $install_args, $subdir )->run_check();
 	}
+
+	public function setup_wsuwp( $subdir = '' ) {
+		$dest_dir = $this->variables['RUN_DIR'] . "/$subdir";
+
+		if ( $subdir ) {
+			mkdir( $dest_dir );
+		}
+
+		$this->proc( Utils\esc_cmd( "cp -r %s/* %s", self::$cache_dir, $dest_dir ) )->run_check();
+
+		if ( ! is_dir( $dest_dir . '/wp-content/mu-plugins' ) ) {
+			mkdir( $dest_dir . '/wp-content/mu-plugins' );
+		}
+
+		if ( ! is_dir( $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins' ) ) {
+			mkdir( $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins' );
+		}
+
+		copy( __DIR__ . '/../extra/wsuwp-load-mu-plugins.php', $dest_dir . '/wp-content/mu-plugins/wsuwp-load-mu-plugins/wsuwp-load-mu-plugins.php' );
+
+		$wsuwp_platform_loader = 'https://github.com/washingtonstateuniversity/WSUWP-Platform/raw/master/www/wp-content/mu-plugins/index.php';
+		$wsuwp_multinetwork_plugin = 'https://github.com/washingtonstateuniversity/WSUWP-Plugin-Multiple-Networks/archive/master.zip';
+		$wsuwp_simple_filters_plugin = 'https://github.com/washingtonstateuniversity/WSUWP-Plugin-MU-Simple-Filters/archive/master.zip';
+
+		$this->proc( Utils\esc_cmd(
+			'curl -sSfL %1$s > %2$s',
+			$wsuwp_platform_loader,
+			$dest_dir . 'wp-content/mu-plugins/index.php'
+		) )->run_check();
+
+		$this->proc( Utils\esc_cmd(
+			'curl -sSfL %1$s > master.zip && unzip master.zip && mv WSUWP-Plugin-Multiple-Networks-master wp-content/mu-plugins/wsuwp-multiple-networks && rm master.zip',
+			$wsuwp_multinetwork_plugin
+		) )->run_check();
+
+		$this->proc( Utils\esc_cmd(
+			'curl -sSfL %1$s > master.zip && unzip master.zip && mv WSUWP-Plugin-MU-Simple-Filters-master wp-content/mu-plugins/wsuwp-mu-simple-filters && rm master.zip',
+			$wsuwp_simple_filters_plugin
+		) )->run_check();
+	}
 }
 

--- a/features/extra/wsuwp-load-mu-plugins.php
+++ b/features/extra/wsuwp-load-mu-plugins.php
@@ -1,0 +1,16 @@
+<?php
+
+add_filter( 'wsuwp_load_mu_plugins', 'wsuwp_add_mu_plugins' );
+/**
+ * Filters the list of MU plugins loaded with the WSUWP Platform.
+ *
+ * @since 0.0.1
+ *
+ * @return array
+ */
+function wsuwp_add_mu_plugins() {
+	return array(
+		'wsuwp-mu-simple-filters/wsuwp-mu-simple-filters.php',
+		'wsuwp-multiple-networks/wsuwp-multiple-networks.php',
+	);
+}

--- a/features/load-wp-cli.feature
+++ b/features/load-wp-cli.feature
@@ -1,7 +1,7 @@
 Feature: Test that WP-CLI loads.
 
   Scenario: WP-CLI loads for your tests
-    Given a WP install
+    Given a WSUWP Platform install
 
     When I run `wp eval 'echo "Hello world.";'`
     Then STDOUT should contain:

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -62,11 +62,10 @@ $steps->Given( "/^a WP install in '([^\s]+)'$/",
 	}
 );
 
-$steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
+$steps->Given( '/^a WSUWP Platform install$/',
 	function ( $world, $type = 'subdirectory' ) {
 		$world->install_wp();
-		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
-		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
+		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => 1 ) )->run_check();
 		$world->setup_wsuwp();
 	}
 );

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -67,6 +67,7 @@ $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
 		$world->install_wp();
 		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
 		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
+		$world->setup_wsuwp();
 	}
 );
 

--- a/features/wsuwp-user.feature
+++ b/features/wsuwp-user.feature
@@ -1,0 +1,10 @@
+Feature: Test the wsuwp user command
+
+  Scenario: WSUWP user command exists
+    Given a WP install
+
+    When I run `wp wsuwp user`
+    Then STDOUT should contain:
+      """
+      usage: wp wsuwp user create <user-email> [--first_name=<first_name>] [--last_name=<last_name>] [--porcelain]
+      """

--- a/features/wsuwp-user.feature
+++ b/features/wsuwp-user.feature
@@ -1,7 +1,7 @@
 Feature: Test the wsuwp user command
 
   Scenario: WSUWP user command exists
-    Given a WP multisite install
+    Given a WSUWP Platform install
 
     When I run `wp wsuwp user`
     Then STDOUT should contain:
@@ -10,7 +10,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Invalid emails are rejected
-    Given a WP multisite install
+    Given a WSUWP Platform install
 
     When I try `wp wsuwp user create notanemail`
     Then the return code should be 1
@@ -20,7 +20,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Non WSU emails are rejected
-    Given a WP multisite install
+    Given a WSUWP Platform install
 
     When I try `wp wsuwp user create user@gmail.com`
     Then the return code should be 1
@@ -30,7 +30,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Usernames under 3 characters are rejected
-    Given a WP multisite install
+    Given a WSUWP Platform install
 
     When I try `wp wsuwp user create ab@wsu.edu`
     Then the return code should be 1
@@ -40,7 +40,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Valid WSU users are created
-    Given a WP multisite install
+    Given a WSUWP Platform install
 
     When I run `wp wsuwp user create valid.user@wsu.edu`
     Then STDOUT should contain:

--- a/features/wsuwp-user.feature
+++ b/features/wsuwp-user.feature
@@ -8,3 +8,45 @@ Feature: Test the wsuwp user command
       """
       usage: wp wsuwp user create <user-email> [--first_name=<first_name>] [--last_name=<last_name>] [--porcelain]
       """
+
+  Scenario: Invalid emails are rejected
+    Given a WP install
+
+    When I try `wp wsuwp user create notanemail`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      'notanemail' is not a valid email.
+      """
+
+  Scenario: Non WSU emails are rejected
+    Given a WP install
+
+    When I try `wp wsuwp user create user@gmail.com`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      'user@gmail.com' is not a valid WSU email.
+      """
+
+  Scenario: Usernames under 3 characters are rejected
+    Given a WP install
+
+    When I try `wp wsuwp user create ab@wsu.edu`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      Username must be at least 3 characters.
+      """
+
+  Scenario: Valid WSU users are created
+    Given a WP install
+
+    When I run `wp wsuwp user create valid.user@wsu.edu`
+    Then STDOUT should contain:
+      """
+      Created user
+      """
+
+    When I try the previous command again
+    Then the return code should be 1

--- a/features/wsuwp-user.feature
+++ b/features/wsuwp-user.feature
@@ -50,3 +50,7 @@ Feature: Test the wsuwp user command
 
     When I try the previous command again
     Then the return code should be 1
+    Then STDERR should contain:
+      """
+      The 'valid.user' username is already registered.
+      """

--- a/features/wsuwp-user.feature
+++ b/features/wsuwp-user.feature
@@ -1,7 +1,7 @@
 Feature: Test the wsuwp user command
 
   Scenario: WSUWP user command exists
-    Given a WP install
+    Given a WP multisite install
 
     When I run `wp wsuwp user`
     Then STDOUT should contain:
@@ -10,7 +10,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Invalid emails are rejected
-    Given a WP install
+    Given a WP multisite install
 
     When I try `wp wsuwp user create notanemail`
     Then the return code should be 1
@@ -20,7 +20,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Non WSU emails are rejected
-    Given a WP install
+    Given a WP multisite install
 
     When I try `wp wsuwp user create user@gmail.com`
     Then the return code should be 1
@@ -30,7 +30,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Usernames under 3 characters are rejected
-    Given a WP install
+    Given a WP multisite install
 
     When I try `wp wsuwp user create ab@wsu.edu`
     Then the return code should be 1
@@ -40,7 +40,7 @@ Feature: Test the wsuwp user command
       """
 
   Scenario: Valid WSU users are created
-    Given a WP install
+    Given a WP multisite install
 
     When I run `wp wsuwp user create valid.user@wsu.edu`
     Then STDOUT should contain:

--- a/features/wsuwp.feature
+++ b/features/wsuwp.feature
@@ -1,0 +1,10 @@
+Feature: Test the wsuwp command
+
+  Scenario: The wsuwp command exists
+    Given a WP install
+
+    When I run `wp wsuwp`
+    Then STDOUT should contain:
+      """
+      usage: wp wsuwp user <command>
+      """

--- a/features/wsuwp.feature
+++ b/features/wsuwp.feature
@@ -1,7 +1,7 @@
 Feature: Test the wsuwp command
 
   Scenario: The wsuwp command exists
-    Given a WP install
+    Given a WSUWP Platform install
 
     When I run `wp wsuwp`
     Then STDOUT should contain:


### PR DESCRIPTION
This customizes WP-CLI's `wp user create` quite a bit so that we can easily add WSU NIDs from the command line.

`wp wsuwp user create jeremy.felt@wsu.edu --first_name=Jeremy --last_name=Felt` will create a user with:

* User: jeremy.felt
* Email: jeremy.felt@wsu.edu
* First Name: Jeremy
* Last Name: Felt

Something like `wp wsuwp user create jeremy.felt@gmail.com` will be rejected with an error that a WSU email was not used.

A future iteration of this can allow for an import via CSV. Another may check ADFS for a matching user.

[Behat](http://behat.org/en/latest/) tests are included as that's what's commonly used with WP-CLI commands.