### PR TITLE
[PR] Implement `wp wsuwp site create` command

### DIFF
--- a/command.php
+++ b/command.php
@@ -5,3 +5,4 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 include_once __DIR__ . '/commands/wsuwp-cli-users.php';
+include_once __DIR__ . '/commands/wsuwp-cli-site.php';

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -17,8 +17,8 @@ class Command {
 	 * <site-url>
 	 * : The domain and path of the new site.
 	 *
-	 * <wsu-nid>
-	 * : The network ID of the first admin for the site.
+	 * <admin-email>
+	 * : The WSU email for first site administrator.
 	 *
 	 * <site-name>
 	 * : The name of the site.
@@ -43,7 +43,7 @@ class Command {
 		global $wpdb;
 		$new_site = new \stdClass;
 
-		list( $new_site->url, $new_site->nid, $new_site->name, $new_site->network ) = $args;
+		list( $new_site->url, $new_site->email, $new_site->name, $new_site->network ) = $args;
 
 		$assoc_args = wp_slash( $assoc_args );
 
@@ -83,7 +83,7 @@ class Command {
 		}
 
 
-		$user_id = email_exists( $new_site->nid );
+		$user_id = email_exists( $new_site->email );
 
 		if ( ! $user_id ) { // Create a new user with a random password
 			WP_CLI::error( 'The user does not exist.' );

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -114,7 +114,7 @@ class Command {
 
 Address: %2$s
 Name: %3$s' ), wp_get_current_user()->user_login , get_site_url( $id ), wp_unslash( $new_site->name ) );
-		wp_mail( get_site_option( 'admin_email' ), sprintf( __( '[%s] New Site Created' ), get_current_site()->site_name ), $content_mail, 'From: "Site Admin" <' . get_site_option( 'admin_email' ) . '>' );
+		wp_mail( get_network_option( $new_site->network, 'admin_email' ), sprintf( __( '[%s] New Site Created' ), $network->site_name ), $content_mail, 'From: "Site Admin" <' . get_network_option( $new_site->network, 'admin_email' ) . '>' );
 
 		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $id );

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -88,6 +88,11 @@ class Command {
 			WP_CLI::error( 'The user does not exist.' );
 		}
 
+		$network = get_network( $new_site->network );
+		if ( ! $network ) {
+			WP_CLI::error( 'The network does not exist.' );
+		}
+
 		$wpdb->hide_errors();
 		$id = wpmu_create_blog( $new_site->domain, $new_site->path, $new_site->name, $user_id , array(
 			'public' => 1,

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -82,7 +82,6 @@ class Command {
 			WP_CLI::error( 'A site with this domain and path combination already exists.' );
 		}
 
-
 		$user_id = email_exists( $new_site->email );
 
 		if ( ! $user_id ) { // Create a new user with a random password

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -27,7 +27,7 @@ class Command {
 	 * : The ID of the network the site should be created under.
 	 *
 	 * [--porcelain]
-	 * : Output just the new user id.
+	 * : Output just the new site id.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -1,0 +1,4 @@
+<?php
+
+namespace WSUWP\CLI\Site;
+use WP_CLI;

--- a/commands/wsuwp-cli-site.php
+++ b/commands/wsuwp-cli-site.php
@@ -2,3 +2,121 @@
 
 namespace WSUWP\CLI\Site;
 use WP_CLI;
+
+/**
+ * WP-CLI command for managing WSUWP sites
+ *
+ * @package WSUWP\CLI\Site;
+ */
+class Command {
+	/**
+	 * Create a new site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <site-url>
+	 * : The domain and path of the new site.
+	 *
+	 * <wsu-nid>
+	 * : The network ID of the first admin for the site.
+	 *
+	 * <site-name>
+	 * : The name of the site.
+	 *
+	 * <network-id>
+	 * : The ID of the network the site should be created under.
+	 *
+	 * [--porcelain]
+	 * : Output just the new user id.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Create site
+	 *     $ wp wsuwp site create web.wsu.edu/sub-site jeremy.felt@wsu.edu "Web Sub Site" 2
+	 *     Success: Created site ID 3 with admin user jeremy.felt
+	 *
+	 *     # Create site and returned only the ID
+	 *     $ wp wsuwp site create web.wsu.edu/sub-site jeremy.felt@wsu.edu "Web Sub Site" 2 --porcelain
+	 *     3
+	 */
+	public function create( $args, $assoc_args ) {
+		global $wpdb;
+		$new_site = new \stdClass;
+
+		list( $new_site->url, $new_site->nid, $new_site->name, $new_site->network ) = $args;
+
+		$assoc_args = wp_slash( $assoc_args );
+
+		$new_site->url = esc_url( $new_site->url );
+		$new_site->domain = wp_parse_url( $new_site->url, PHP_URL_HOST );
+		$new_site->path = trim( wp_parse_url( $new_site->url, PHP_URL_PATH ), '/' );
+
+		if ( strpos( $new_site->path, '/' ) ) {
+			WP_CLI::error( 'A site can only have one path.' );
+		}
+
+		if ( 0 === substr_count( $new_site->domain, '.' ) ) {
+			WP_CLI::error( "'{$new_site->domain}'" . ' is not a valid domain.' );
+		}
+
+		$new_site->path = '/' . trailingslashit( $new_site->path );
+
+		if ( wsuwp_validate_domain( $new_site->domain ) ) {
+			$new_site->domain = strtolower( $new_site->domain );
+		} else {
+			WP_CLI::error( 'Invalid site address. Non valid characters were found in the domain.' );
+		}
+
+		if ( wsuwp_validate_path( $new_site->path ) ) {
+			$new_site->path = strtolower( $new_site->path );
+		} else {
+			WP_CLI::error( 'Invalid site path. Non standard characters were found in the path name.' );
+		}
+
+		$existing = get_sites( array(
+			'domain' => $new_site->domain,
+			'path' => $new_site->path,
+		) );
+
+		if ( 0 !== count( $existing ) ) {
+			WP_CLI::error( 'A site with this domain and path combination already exists.' );
+		}
+
+
+		$user_id = email_exists( $new_site->nid );
+
+		if ( ! $user_id ) { // Create a new user with a random password
+			WP_CLI::error( 'The user does not exist.' );
+		}
+
+		$wpdb->hide_errors();
+		$id = wpmu_create_blog( $new_site->domain, $new_site->path, $new_site->name, $user_id , array(
+			'public' => 1,
+		), $new_site->network );
+		$wpdb->show_errors();
+
+		if ( is_wp_error( $id ) ) {
+			WP_CLI::error( $id->get_error_message() );
+		}
+
+		if ( ! is_super_admin( $user_id ) && ! get_user_option( 'primary_blog', $user_id ) ) {
+			update_user_option( $user_id, 'primary_blog', $id, true );
+		}
+
+		// Clear any stale cache related to this domain and path request. See sunrise.
+		wp_cache_delete( $new_site->domain . $new_site->path, 'wsuwp:site' );
+
+		$content_mail = sprintf( __( 'New site created by %1$s
+
+Address: %2$s
+Name: %3$s' ), wp_get_current_user()->user_login , get_site_url( $id ), wp_unslash( $new_site->name ) );
+		wp_mail( get_site_option( 'admin_email' ), sprintf( __( '[%s] New Site Created' ), get_current_site()->site_name ), $content_mail, 'From: "Site Admin" <' . get_site_option( 'admin_email' ) . '>' );
+
+		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			WP_CLI::line( $id );
+		} else {
+			WP_CLI::success( "Created site $id." );
+		}
+	}
+}
+WP_CLI::add_command( 'wsuwp site', 'WSUWP\CLI\Site\Command' );

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -327,8 +327,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$install_args = array(
 			'url' => 'http://example.com',
 			'title' => 'WP CLI Site',
-			'admin_user' => 'admin',
-			'admin_email' => 'admin@example.com',
+			'admin_user' => 'wsu.admin',
+			'admin_email' => 'wsu.admin@wsu.edu',
 			'admin_password' => 'password1'
 		);
 

--- a/features/wsuwp-site.feature
+++ b/features/wsuwp-site.feature
@@ -6,7 +6,7 @@ Feature: Test the wsuwp site command
     When I run `wp wsuwp site`
     Then STDOUT should contain:
       """
-      usage: wp wsuwp site create <site-url> <wsu-nid> <site-name> <network-id> [--porcelain]
+      usage: wp wsuwp site create <site-url> <admin-email> <site-name> <network-id> [--porcelain]
       """
 
   Scenario: A complete wsuwp site create command is issued

--- a/features/wsuwp-site.feature
+++ b/features/wsuwp-site.feature
@@ -12,7 +12,7 @@ Feature: Test the wsuwp site command
   Scenario: A complete wsuwp site create command is issued
     Given a WSUWP Platform install
 
-    When I run `wp wsuwp site create crimsonpages.org/jeremy-felt jeremy.felt@wsu.edu "Jeremy Felt's Portfolio" 1`
+    When I run `wp wsuwp site create crimsonpages.org/jeremy-felt wsu.admin@wsu.edu "Jeremy Felt's Portfolio" 1`
     Then STDOUT should contain:
       """
       Created site
@@ -22,23 +22,23 @@ Feature: Test the wsuwp site command
     Then the return code should be 1
     Then STDERR should contain:
       """
-      crimsonpages.org/jeremy-felt is already a site
+      A site with this domain and path combination already exists.
       """
 
   Scenario: A site URL with multiple paths is rejected
     Given a WSUWP Platform install
 
-    When I try `wp wsuwp site create crimsonpages.org/jeremy-felt/second jeremy.felt@wsu.edu "Site 2" 1`
+    When I try `wp wsuwp site create crimsonpages.org/jeremy-felt/second wsu.admin@wsu.edu "Site 2" 1`
     Then the return code should be 1
     Then STDERR should contain:
       """
-      A site can only have one path
+      A site can only have one path.
       """
 
   Scenario: A site URL with an invalid domain
     Given a WSUWP Platform install
 
-    When I try `wp wsuwp site create crimsonpages/jeremy-felt jeremy.felt@wsu.edu "Site Invalid" 1`
+    When I try `wp wsuwp site create crimsonpages/jeremy-felt wsu.admin@wsu.edu "Site Invalid" 1`
     Then the return code should be 1
     Then STDERR should contain:
       """
@@ -48,9 +48,9 @@ Feature: Test the wsuwp site command
   Scenario: A site URL with an invalid path
     Given a WSUWP Platform install
 
-    When I try `wp wsuwp site create crimsonpages.org/jeremy.felt jeremy.felt@wsu.edu "Site Invalid" 1`
+    When I try `wp wsuwp site create crimsonpages.org/jeremy.felt wsu.admin@wsu.edu "Site Invalid" 1`
     Then the return code should be 1
     Then STDERR should contain:
       """
-      'jeremy.felt' is not a valid path.
+      Invalid site path. Non standard characters were found in the path name.
       """

--- a/features/wsuwp-site.feature
+++ b/features/wsuwp-site.feature
@@ -1,0 +1,56 @@
+Feature: Test the wsuwp site command
+
+  Scenario: WSUWP site command exists
+    Given a WSUWP Platform install
+
+    When I run `wp wsuwp site`
+    Then STDOUT should contain:
+      """
+      usage: wp wsuwp site create <site-url> <wsu-nid> <site-name> <network-id> [--porcelain]
+      """
+
+  Scenario: A complete wsuwp site create command is issued
+    Given a WSUWP Platform install
+
+    When I run `wp wsuwp site create crimsonpages.org/jeremy-felt jeremy.felt@wsu.edu "Jeremy Felt's Portfolio" 1`
+    Then STDOUT should contain:
+      """
+      Created site
+      """
+
+    When I try the previous command again
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      crimsonpages.org/jeremy-felt is already a site
+      """
+
+  Scenario: A site URL with multiple paths is rejected
+    Given a WSUWP Platform install
+
+    When I try `wp wsuwp site create crimsonpages.org/jeremy-felt/second jeremy.felt@wsu.edu "Site 2" 1`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      A site can only have one path
+      """
+
+  Scenario: A site URL with an invalid domain
+    Given a WSUWP Platform install
+
+    When I try `wp wsuwp site create crimsonpages/jeremy-felt jeremy.felt@wsu.edu "Site Invalid" 1`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      'crimsonpages' is not a valid domain.
+      """
+
+  Scenario: A site URL with an invalid path
+    Given a WSUWP Platform install
+
+    When I try `wp wsuwp site create crimsonpages.org/jeremy.felt jeremy.felt@wsu.edu "Site Invalid" 1`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      'jeremy.felt' is not a valid path.
+      """

--- a/features/wsuwp-site.feature
+++ b/features/wsuwp-site.feature
@@ -54,3 +54,13 @@ Feature: Test the wsuwp site command
       """
       Invalid site path. Non standard characters were found in the path name.
       """
+
+  Scenario: A network ID that does not exist
+    Given a WSUWP Platform install
+
+    When I try `wp wsuwp site create crimsonpages.org/network-invalid wsu.admin@wsu.edu "Network invalid" 2`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      The network does not exist.
+      """

--- a/features/wsuwp.feature
+++ b/features/wsuwp.feature
@@ -6,5 +6,5 @@ Feature: Test the wsuwp command
     When I run `wp wsuwp`
     Then STDOUT should contain:
       """
-      usage: wp wsuwp user <command>
+      usage: wp wsuwp
       """


### PR DESCRIPTION
This allows us to create sites via WP-CLI that match the custom new site screen we've built for WSUWP.

`wp wsuwp site create web.wsu.edu/sub-site jeremy.felt@wsu.edu "Web Sub Site" 3` creates a new site with the web.wsu.edu/sub-site URL on network ID 3.